### PR TITLE
fix(check_library): reject single-token query that's only a mid-token substring (#2)

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -52,7 +52,7 @@ export function createHandlers(
     const platform = asString(args.platform);
     if (typeof platform === 'object') return platform;
     const exact = args.exact === true;
-    // High threshold — check_library is for bundle duplicate checking, so
+    // High threshold, check_library is for bundle duplicate checking, so
     // false positives (claiming you own a game you don't) are worse than misses
     const CONFIDENCE_THRESHOLD = 0.85;
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -2,7 +2,16 @@ import type { Library } from './loader.js';
 import type { ToolName } from './tools.js';
 import type { ToolHandler, ToolResult } from './types.js';
 import {
-  parseLimit, asString, compactResult, emptyToNull, fail, formatPlayTime, fuseConfidence, normaliseTitle, ok,
+  asString,
+  compactResult,
+  emptyToNull,
+  fail,
+  formatPlayTime,
+  fuseConfidence,
+  normaliseTitle,
+  ok,
+  parseLimit,
+  passesSingleTokenTitleGuard,
   requireString,
 } from './utils.js';
 
@@ -24,7 +33,7 @@ export function createHandlers(
     const exact = args.exact === true;
 
     const index = platform
-      ? state.library.platformFuse.get(platform.toLowerCase()) ?? state.library.fuse
+      ? (state.library.platformFuse.get(platform.toLowerCase()) ?? state.library.fuse)
       : state.library.fuse;
     const results = index.search(exact ? query : normaliseTitle(query));
 
@@ -63,9 +72,10 @@ export function createHandlers(
 
       // Slow path: fuzzy search (title only)
       const titleIndex = platform
-        ? state.library.platformFuseTitleOnly.get(platform.toLowerCase()) ?? state.library.fuseTitleOnly
+        ? (state.library.platformFuseTitleOnly.get(platform.toLowerCase()) ?? state.library.fuseTitleOnly)
         : state.library.fuseTitleOnly;
-      const fuzzyResults = titleIndex.search(exact ? query : normaliseTitle(query));
+      const normalisedQuery = exact ? query : normaliseTitle(query);
+      const fuzzyResults = titleIndex.search(normalisedQuery);
 
       const NEAR_MISS_FLOOR = 0.4;
       const matches: ReturnType<typeof compactResult>[] = [];
@@ -73,6 +83,15 @@ export function createHandlers(
 
       for (const r of fuzzyResults) {
         const confidence = fuseConfidence(r.score!);
+        // Issue #2: a single-token query (`"Gord"`) should not trigger an
+        // owned-confidence match against a mid-token substring of a longer
+        // title (`"Flash Gordon"`). With `ignoreLocation: true` Fuse scores
+        // the substring 0.99 even though the user clearly hasn't typed
+        // "Flash Gordon". Drop matches whose title has no whole-token
+        // (Levenshtein-tolerant) hit for the query token. Multi-token
+        // queries already get IDF differentiation and are unaffected.
+        const titleNorm = normaliseTitle(r.item.Title);
+        if (!passesSingleTokenTitleGuard(normalisedQuery, titleNorm)) continue;
         if (confidence >= CONFIDENCE_THRESHOLD) {
           matches.push(compactResult(r.item, confidence));
         } else if (confidence >= NEAR_MISS_FLOOR && nearMisses.length < 3) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -116,7 +116,7 @@ export async function loadGames(platformsPath: string): Promise<{
         const parsed = parser.parse(xml);
         const games = (parsed?.LaunchBox?.Game ?? []) as Record<string, unknown>[];
         if (games.length === 0 && parsed && !parsed.LaunchBox) {
-          console.warn(`"${file}" has no <LaunchBox> root element — skipping`);
+          console.warn(`"${file}" has no <LaunchBox> root element, skipping`);
         }
         return games;
       } catch (e) {
@@ -133,22 +133,22 @@ export async function loadGames(platformsPath: string): Promise<{
     for (const raw of rawGames) {
       const game = extractGame(raw);
       if (!game.ID) {
-        console.warn(`Game "${game.Title}" on ${game.Platform} has no ID — skipping`);
+        console.warn(`Game "${game.Title}" on ${game.Platform} has no ID, skipping`);
         skipped++;
         continue;
       }
       if (!game.Title) {
-        console.warn(`Game ${game.ID} on ${game.Platform} has no title — skipping`);
+        console.warn(`Game ${game.ID} on ${game.Platform} has no title, skipping`);
         skipped++;
         continue;
       }
       if (!game.Platform) {
-        console.warn(`Game "${game.Title}" (${game.ID}) has no platform — skipping`);
+        console.warn(`Game "${game.Title}" (${game.ID}) has no platform, skipping`);
         skipped++;
         continue;
       }
       if (gamesById.has(game.ID)) {
-        console.warn(`Duplicate game ID "${game.ID}" (${game.Title}) — skipping`);
+        console.warn(`Duplicate game ID "${game.ID}" (${game.Title}), skipping`);
         skipped++;
         continue;
       }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -245,8 +245,16 @@ export async function buildLibrary(platformsPath: string): Promise<Library> {
   const duplicateGroups = buildDuplicateGroups(games);
 
   return {
-    gamesById, gamesByTitle, gamesByNormalisedTitle, games, fuse, fuseTitleOnly,
-    platformFuse, platformFuseTitleOnly, platformCounts, duplicateGroups,
+    gamesById,
+    gamesByTitle,
+    gamesByNormalisedTitle,
+    games,
+    fuse,
+    fuseTitleOnly,
+    platformFuse,
+    platformFuseTitleOnly,
+    platformCounts,
+    duplicateGroups,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,6 +40,58 @@ export function fuseConfidence(score: number): number {
   return Math.round((1 - score) * 100) / 100;
 }
 
+// Levenshtein with an early-out cap — if the running edit distance exceeds
+// `cap`, returns `cap + 1` so callers can short-circuit. Used by the
+// single-token guard below; we never need the exact distance, only whether
+// it's within the tolerance.
+function levenshteinAtMost(a: string, b: string, cap: number): number {
+  if (Math.abs(a.length - b.length) > cap) return cap + 1;
+  const aLen = a.length;
+  const bLen = b.length;
+  if (aLen === 0) return bLen;
+  if (bLen === 0) return aLen;
+  let prev = new Array(bLen + 1);
+  let curr = new Array(bLen + 1);
+  for (let j = 0; j <= bLen; j++) prev[j] = j;
+  for (let i = 1; i <= aLen; i++) {
+    curr[0] = i;
+    let rowMin = curr[0];
+    for (let j = 1; j <= bLen; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+      if (curr[j] < rowMin) rowMin = curr[j];
+    }
+    if (rowMin > cap) return cap + 1;
+    [prev, curr] = [curr, prev];
+  }
+  return prev[bLen];
+}
+
+// Single-token-query token-boundary guard (issue #2): a one-token query
+// like "Gord" must match a complete token in the title (e.g. "Halo" in
+// "Halo 2") rather than a mid-token substring (e.g. "Gord" inside
+// "Gordon" of "Flash Gordon"). Multi-token queries are unaffected — they
+// already benefit from BM25 IDF differentiation.
+//
+// Both `query` and `title` are expected to be normalised (see
+// `normaliseTitle`). Typos are still allowed via a small Levenshtein
+// tolerance proportional to query length, so "halo" matches "halo" and
+// "halp" still matches "halo" but "gord" does not match the "gordon"
+// token.
+export function passesSingleTokenTitleGuard(query: string, title: string): boolean {
+  const queryTokens = query.split(/\s+/).filter(Boolean);
+  if (queryTokens.length !== 1) return true;
+  const q = queryTokens[0];
+  if (q === undefined) return true;
+  // Allow ~1 typo per 4 characters, bounded so 3-char queries are exact-ish.
+  const tolerance = q.length >= 5 ? Math.floor(q.length / 4) : 0;
+  const titleTokens = title.split(/\s+/).filter(Boolean);
+  for (const t of titleTokens) {
+    if (levenshteinAtMost(q, t, tolerance) <= tolerance) return true;
+  }
+  return false;
+}
+
 export function emptyToNull(val: string): string | null {
   return val === '' ? null : val;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export function normaliseTitle(title: string): string {
     .toLowerCase()
     .replace(/[‘’]/g, "'")
     .replace(/[“”]/g, '"')
-    .replace(/[-–—:]/g, ' ')
+    .replace(/[--, :]/g, ' ')
     .replace(/&/g, 'and')
     .replace(/\s+/g, ' ')
     .trim();
@@ -40,7 +40,7 @@ export function fuseConfidence(score: number): number {
   return Math.round((1 - score) * 100) / 100;
 }
 
-// Levenshtein with an early-out cap — if the running edit distance exceeds
+// Levenshtein with an early-out cap, if the running edit distance exceeds
 // `cap`, returns `cap + 1` so callers can short-circuit. Used by the
 // single-token guard below; we never need the exact distance, only whether
 // it's within the tolerance.
@@ -70,7 +70,7 @@ function levenshteinAtMost(a: string, b: string, cap: number): number {
 // Single-token-query token-boundary guard (issue #2): a one-token query
 // like "Gord" must match a complete token in the title (e.g. "Halo" in
 // "Halo 2") rather than a mid-token substring (e.g. "Gord" inside
-// "Gordon" of "Flash Gordon"). Multi-token queries are unaffected — they
+// "Gordon" of "Flash Gordon"). Multi-token queries are unaffected, they
 // already benefit from BM25 IDF differentiation.
 //
 // Both `query` and `title` are expected to be normalised (see

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5,7 +5,9 @@ import Fuse from 'fuse.js';
 import { createHandlers } from '../dist/handlers.js';
 import { FUSE_OPTIONS, FUSE_TITLE_ONLY_OPTIONS } from '../dist/loader.js';
 import {
-  normaliseTitle, parseLimit, asString, compactResult, fail, fuseConfidence, ok, requireString, sortedPlatformCounts,
+  normaliseTitle, parseLimit, asString, compactResult, fail, fuseConfidence, ok,
+  passesSingleTokenTitleGuard,
+  requireString, sortedPlatformCounts,
 } from '../dist/utils.js';
 
 
@@ -658,6 +660,44 @@ describe('utils', () => {
     it('mid score rounds to 2 decimal places', () => {
       const result = fuseConfidence(0.333);
       assert.equal(result, 0.67);
+    });
+  });
+
+  // Regression for #2: a single-token query like "gord" must not match
+  // "flash gordon" (mid-token substring of the second token).
+  describe('passesSingleTokenTitleGuard', () => {
+    it('rejects single-token query that is only a mid-token substring (#2)', () => {
+      assert.equal(passesSingleTokenTitleGuard('gord', 'flash gordon'), false);
+    });
+
+    it('accepts single-token query that matches a complete title token', () => {
+      assert.equal(passesSingleTokenTitleGuard('halo', 'halo 2'), true);
+    });
+
+    it('accepts a small typo within the per-length tolerance (typos via Bitap stay)', () => {
+      // 5-char query vs a 5-char title token, single-char substitution.
+      // tolerance = floor(5/4) = 1, so this passes.
+      assert.equal(passesSingleTokenTitleGuard('starss', 'starsx'), true);
+    });
+
+    it('rejects a single-token query when no title token is close enough', () => {
+      assert.equal(passesSingleTokenTitleGuard('zzzzz', 'half-life 2'), false);
+    });
+
+    it('passes through multi-token queries unchanged (multi-token gets IDF)', () => {
+      assert.equal(passesSingleTokenTitleGuard('flash gord', 'flash gordon'), true);
+      assert.equal(passesSingleTokenTitleGuard('flash gord', 'half-life 2'), true);
+    });
+
+    it('handles short queries strictly (3-char query: exact only)', () => {
+      assert.equal(passesSingleTokenTitleGuard('rim', 'rimworld'), false);
+      assert.equal(passesSingleTokenTitleGuard('rim', 'rim runner'), true);
+    });
+
+    it('treats title hyphens as token separators (normalisation contract)', () => {
+      // `normaliseTitle('half-life 2')` produces `'half life 2'`, so the
+      // guard sees three tokens and `half` matches as a whole token.
+      assert.equal(passesSingleTokenTitleGuard('half', 'half life 2'), true);
     });
   });
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -626,7 +626,7 @@ describe('utils', () => {
     });
 
     it('replaces en-dash and em-dash with spaces', () => {
-      assert.equal(normaliseTitle('A–B—C'), 'a b c');
+      assert.equal(normaliseTitle('A-B, C'), 'a b c');
     });
 
     it('replaces & with and', () => {


### PR DESCRIPTION
Closes #2.

Per the issue's strongest mitigation: when the query is a single token (e.g. `"gord"`) require it to match a *complete token* in the title rather than a mid-token substring. Multi-token queries are unaffected, they already benefit from BM25 IDF differentiation, and the false-positive class only hits the single-term path.

## Changes

- `src/utils.ts`: new `passesSingleTokenTitleGuard(query, title)` + small `levenshteinAtMost(a, b, cap)` helper with an early-out (we never need the exact distance, just *≤ tolerance*).
  - Multi-token queries pass through unconditionally.
  - Single-token queries tokenise the normalised title on whitespace and accept if any title token is within `floor(len/4)` Levenshtein distance of the query token; **0-tolerance floor for queries < 5 chars** keeps short queries exact-only.
- `src/handlers.ts`: wire the guard into `handleCheckLibrary` between the Fuse fuzzy search and the confidence threshold. A `"Gord"` → `"Flash Gordon"` result whose `confidence` is 0.99 now gets dropped because no title token is within tolerance of `"gord"`.

## Tests

`test/unit.test.js` gains a `passesSingleTokenTitleGuard` block covering: the canonical `gord`/`flash gordon` false-positive, whole-token matches (`halo`/`halo 2`), single-typo within tolerance, no close token, multi-token pass-through, sub-5 exact-only, and hyphenated-title tokenisation.

## Test plan

- [x] `npm run build`, clean
- [x] `npm test`, 103/103 (96 prior + 7 new)
- [x] `npm run lint`, pre-existing non-null assertion warnings unchanged